### PR TITLE
3.0.0

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,2 +1,0 @@
-[flake8]
-extend-ignore = W605

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,14 +17,14 @@ This release is a major rewrite that includes changes breaking existing use
         - `from-domain-mismatch` - The `from_domain` rule `meta` value does not match the from domain of the email message
         - `domain-authentication-failed` - Domain authentication failed for a rule with a `from_domain` `meta` value set. This warning can be suppressed by setting the `auth_optional` `meta` value to `true`
         - `safe-rule-missing-from-domain` - A rule with a `category` of `safe` does not have the required `from_domain` `meta` value
-  - Trusted domains are now called YARA safe optional domains
+  - Trusted domains are now called implicit safe domains
 - API changes
-  - `trusted_domains` renamed to `yara_safe_optional_domains`
+  - `trusted_domains` renamed to `implisit_safe_domains`
   - `trusted_domains_yara_safe_required` parameter removed
   - `include_sld_in_auth_check` parameter removed
   - Returned data structure changed (see docs for details)
 - CLI changes
-  - `--trusted-domains` renamed to `--yara-safe-optional-domains`
+  - `--trusted-domains` renamed to `--implicit-safe-domains`
   - `--trusted-domains-yara` removed
   - `--sld` removed
   - Log output delimiter changed from `:` to `|` to avoid conflicting with JSON

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,8 @@ This release is a major rewrite that includes changes breaking existing use
 - Logic changes
   - Rules with a category of `safe` must have a `from_domain` `meta` value for the category to apply
     - This logic replaces `trusted_domains_yara_safe_required`
-    - `trusted_domain`, `trusted_domain_yara_safe_required`, and `auth_optional` removed from results
+    -  `trusted_domain_yara_safe_required`, and `auth_optional` removed from results
+  - The `auth_optional`rule `meta` key only applies to that rule 
   - Warnings are located inside a `warnings` list in each match, instead of as a `verdict`
     - A rule category does not apply if one or more warning is raised
       - Possible warnings include
@@ -16,12 +17,12 @@ This release is a major rewrite that includes changes breaking existing use
         - `from-domain-mismatch` - The `from_domain` rule `meta` value does not match the from domain of the email message
         - `domain-authentication-failed` - Domain authentication failed for a rule with a `from_domain` `meta` value set. This warning can be suppressed by setting the `auth_optional` `meta` value to `true`
         - `safe-rule-missing-from-domain` - A rule with a `category` of `safe` does not have the required `from_domain` `meta` value
-  - The `auth_optional`rule `meta` value only applies to that rule
   - Trusted domains are now called YARA safe optional domains
 - API changes
   - `trusted_domains` renamed to `yara_safe_optional_domains`
   - `trusted_domains_yara_safe_required` parameter removed
   - `include_sld_in_auth_check` parameter removed
+  - Returned data structure changed (see docs for details)
 - CLI changes
   - `--trusted-domains` renamed to `--yara-safe-optional-domains`
   - `--trusted-domains-yara` removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,14 +11,13 @@ This release is a major rewrite that includes changes breaking existing use
     - `auth_pass_not_yara_safe` verdict removed
     - `trusted_domain`, `trusted_domain_yara_safe_required`, and `auth_optional` removed from results
   - The `auth_optional`rule `meta` value only applies to that rule
-  - Including the second-level domain (SLD) in authentication checks is now set by the `include_sld` rule `meta` value
   - Trusted domains are now called YARA optional domains
 - API changes
-  - `trusted_domains` renamed to `yara_optional_domains`
+  - `trusted_domains` renamed to `yara_safe_optional_domains`
   - `trusted_domains_yara_safe_required` parameter removed
   - `include_sld_in_auth_check` parameter removed
 - CLI changes
-  - `--trusted-domains` renamed to `--yara-optional-domains`
+  - `--trusted-domains` renamed to `--yara-safe-optional-domains`
   - `--trusted-domains-yara` removed
   - `--sld` removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,18 @@
 This release is a major rewrite that includes changes breaking existing use
 
 - Logic changes
-  - Rules with a category of `safe` must have a matching `from_domain` `meta` value for the category to apply
+  - Rules with a category of `safe` must have a `from_domain` `meta` value for the category to apply
     - This logic replaces `trusted_domains_yara_safe_required`
-    - `auth_pass_not_yara_safe` verdict removed
     - `trusted_domain`, `trusted_domain_yara_safe_required`, and `auth_optional` removed from results
+  - Warnings are located inside a `warnings` list in each match, instead of as a `verdict`
+    - A rule category does not apply if one or more warning is raised
+      - Possible warnings include
+        - `unexpected-attachment` - A rule with a `meta` value `no_attachment` or `no_attachments` set to `true` matched an email with one or more attachments
+        - `from-domain-mismatch` - The `from_domain` rule `meta` value does not match the from domain of the email message
+        - `domain-authentication-failed` - Domain authentication failed for a rule with a `from_domain` `meta` value set. This warning can be suppressed by setting the `auth_optional` `meta` value to `true`
+        - `safe-rule-missing-from-domain` - A rule with a `category` of `safe` does not have the required `from_domain` `meta` value
   - The `auth_optional`rule `meta` value only applies to that rule
-  - Trusted domains are now called YARA optional domains
+  - Trusted domains are now called YARA safe optional domains
 - API changes
   - `trusted_domains` renamed to `yara_safe_optional_domains`
   - `trusted_domains_yara_safe_required` parameter removed
@@ -20,6 +26,7 @@ This release is a major rewrite that includes changes breaking existing use
   - `--trusted-domains` renamed to `--yara-safe-optional-domains`
   - `--trusted-domains-yara` removed
   - `--sld` removed
+  - Log output delimiter changed from `:` to `|` to avoid conflicting with JSON
 
 ## 2.1.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,10 +13,16 @@ This release is a major rewrite that includes changes breaking existing use
   - Warnings are located inside a `warnings` list in each match, instead of as a `verdict`
     - A rule category does not apply if one or more warning is raised
       - Possible warnings include
-        - `unexpected-attachment` - A rule with a `meta` value `no_attachment` or `no_attachments` set to `true` matched an email with one or more attachments
-        - `from-domain-mismatch` - The `from_domain` rule `meta` value does not match the from domain of the email message
-        - `domain-authentication-failed` - Domain authentication failed for a rule with a `from_domain` `meta` value set. This warning can be suppressed by setting the `auth_optional` `meta` value to `true`
-        - `safe-rule-missing-from-domain` - A rule with a `category` of `safe` does not have the required `from_domain` `meta` value
+        - `domain-authentication-failed` - Authentication of the message
+            From domain failed
+          - `from-domain-mismatch` - The message From domain did not exactly
+            match the value of the `meta` key `from_domain`
+          - `safe-rule-missing-from-domain` - The rule is missing a
+            `from_domain` `meta` key that is required for rules with the
+            `category` meta key set to `safe`
+          - `unexpected-attachment` - An email win an attachment matched a
+            rule with the `meta` key `no attachment` or `no_attachments`
+            set to `true`
   - Trusted domains are now called implicit safe domains
 - API changes
   - `trusted_domains` renamed to `implisit_safe_domains`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,27 @@
 # Changelog
 
+## 3.0.0
+
+*Warning*
+This release is a major rewrite that includes changes breaking existing use
+
+- Logic changes
+  - Rules with a category of `safe` must have a matching `from_domain` `meta` value for the category to apply
+    - This logic replaces `trusted_domains_yara_safe_required`
+    - `auth_pass_not_yara_safe` verdict removed
+    - `trusted_domain`, `trusted_domain_yara_safe_required`, and `auth_optional` removed from results
+  - The `auth_optional`rule `meta` value only applies to that rule
+  - Including the second-level domain (SLD) in authentication checks is now set by the `include_sld` rule `meta` value
+  - Trusted domains are now called YARA optional domains
+- API changes
+  - `trusted_domains` renamed to `yara_optional_domains`
+  - `trusted_domains_yara_safe_required` parameter removed
+  - `include_sld_in_auth_check` parameter removed
+- CLI changes
+  - `--trusted-domains` renamed to `--yara-optional-domains`
+  - `--trusted-domains-yara` removed
+  - `--sld` removed
+
 ## 2.1.0
 
 - Use email body content to brute force password-protected ZIPs

--- a/docs/source/api.md
+++ b/docs/source/api.md
@@ -1,6 +1,6 @@
 # API
 
-```eval-rst}
+```{eval-rst}
 .. automodule:: yaramail
    :members:
    :undoc-members:

--- a/docs/source/cli.md
+++ b/docs/source/cli.md
@@ -8,7 +8,7 @@ usage: A YARA scanner for emails [-h] [-V] [-v] [-m] [-o] [-r] [-b] [-s] [-t]
                                  [--header-body-rules HEADER_BODY_RULES]
                                  [--attachment-rules ATTACHMENT_RULES]
                                  [--passwords PASSWORDS]
-                                 [--yara-safe-optional-domains YARA_SAFE_OPTIONAL_DOMAINS]
+                                 [--implicit-safe-domains IMPLICIT_SAFE_DOMAINS]
                                  [--max-zip-depth MAX_ZIP_DEPTH]
                                  scan_path
 
@@ -55,11 +55,11 @@ options:
                         Filename of a list of passwords to try against
                         password-protected files in addition to email body
                         content (default: passwords.txt)
-  --yara-safe-optional-domains YARA_SAFE_OPTIONAL_DOMAINS
+  --implicit-safe-domains IMPLICIT_SAFE_DOMAINS
                         Filename of a list of message From domains that return
                         a safe verdict if the domain is authenticated and no
                         YARA categories match other than safe (default:
-                        yara_safe_optional_domains.txt)
+                        implicit_safe_domains.txt)
   --max-zip-depth MAX_ZIP_DEPTH
                         The maximum number of times to recurse into nested ZIP
                         files (default: None)

--- a/docs/source/cli.md
+++ b/docs/source/cli.md
@@ -8,8 +8,7 @@ usage: A YARA scanner for emails [-h] [-V] [-v] [-m] [-o] [-r] [-b] [-s] [-t]
                                  [--header-body-rules HEADER_BODY_RULES]
                                  [--attachment-rules ATTACHMENT_RULES]
                                  [--passwords PASSWORDS]
-                                 [--trusted-domains TRUSTED_DOMAINS]
-                                 [--trusted-domains-yara TRUSTED_DOMAINS_YARA]
+                                 [--yara-safe-optional-domains YARA_SAFE_OPTIONAL_DOMAINS]
                                  [--max-zip-depth MAX_ZIP_DEPTH]
                                  scan_path
 
@@ -54,17 +53,13 @@ options:
                         attachment.yar)
   --passwords PASSWORDS
                         Filename of a list of passwords to try against
-                        password-protected files (default: passwords.txt)
-  --trusted-domains TRUSTED_DOMAINS
+                        password-protected files in addition to email body
+                        content (default: passwords.txt)
+  --yara-safe-optional-domains YARA_SAFE_OPTIONAL_DOMAINS
                         Filename of a list of message From domains that return
                         a safe verdict if the domain is authenticated and no
                         YARA categories match other than safe (default:
-                        trusted_domains.txt)
-  --trusted-domains-yara TRUSTED_DOMAINS_YARA
-                        Filename of a list of message From domains that
-                        require an authenticated from domain and YARA safe
-                        verdict (default:
-                        trusted_domains_yara_safe_required.txt)
+                        yara_safe_optional_domains.txt)
   --max-zip-depth MAX_ZIP_DEPTH
                         The maximum number of times to recurse into nested ZIP
                         files (default: None)

--- a/docs/source/tutorial.md
+++ b/docs/source/tutorial.md
@@ -129,7 +129,7 @@ try:
         body_rules="body.yar",
         header_body_rules="header_body.yar",
         attachment_rules="attachment.yar",
-        trusted_domains="trusted_domains.txt",
+        trusted_domains="yara_safe_optional_domains.txt",
         trusted_domains_yara_safe_required="trusted_yara_safe_required.txt")
 except Exception as e:
     logger.error(f"Could not initialize the scanner: {e}")
@@ -573,7 +573,7 @@ try:
         body_rules="body.yar",
         header_body_rules="header_body.yar",
         attachment_rules="attachment.yar",
-        trusted_domains="trusted_domains.txt",
+        trusted_domains="yara_safe_optional_domains.txt",
         trusted_domains_yara_safe_required="trusted_yara_safe_required.txt")
 except Exception as e:
     logger.error(f"Could not initialize the scanner: {e}")

--- a/docs/source/tutorial.md
+++ b/docs/source/tutorial.md
@@ -336,7 +336,8 @@ types.
 
 :::{tip}
 A helpful list of [file type signatures][file signatures] can be found on
-Wikipedia.
+Wikipedia. The [Library of Congress][LOC] maintains extensive descriptions of
+many different file types.
 :::
 
 #### Small ISO files
@@ -654,5 +655,6 @@ for email in emails:
 [CyberChef]: https://github.com/gchq/CyberChef/releases
 [EDGAR]: https://www.sec.gov/edgar/searchedgar/companysearch.html
 [file signatures]: https://en.wikipedia.org/wiki/List_of_file_signatures
+[LOC]: https://www.loc.gov/preservation/digital/formats/fdd/browse_list.shtml
 [filesize]: https://yara.readthedocs.io/en/stable/writingrules.html#file-size
 [exiftool]: https://exiftool.org/

--- a/docs/source/tutorial.md
+++ b/docs/source/tutorial.md
@@ -135,13 +135,13 @@ that category. If multiple categories are listed, the verdict is set to
 `ambiguous`. If no categories are listed, the verdict is set to `None`.
 
 :::{note}
-In extremely rare cases, a domain may send a wide variety of automated emails
-that do not fit into patterns, making YARA rules impractical. to account for
-this, a domain can be added to the `implicit_safe_domains_list`, which will
-add a `category` of `safe` to every email from that domain, as long as the
-domain is authenticated. The emails will still be scanned by YARA, so any
-YARA category matches other than `safe` will still return an `anbigious`
-verdict.
+In extremely rare cases, a trusted domain may send a wide variety of automated 
+emails that do not fit into patterns, making YARA rules impractical. 
+To account for this, a domain can be added to the `implicit_safe_domains`
+list, which will add a `category` of `safe` to every email from that
+domain, as long as the domain is authenticated. The emails will still be
+scanned by YARA, so any YARA category matches other than `safe` will still
+return an `ambiguous` verdict.
 
 *Only do this as a last resort*, because implicitly trusting all emails from
 a domain would cause a malicious email to be categorized as `safe`.
@@ -151,15 +151,19 @@ a domain would cause a malicious email to be categorized as `safe`.
 
 Do not require domain authentication for the rule's category to apply.
 
+:::{note}
+This only applies when `from_domain` is set.
+:::
+
 :::{important}
 Only set this key to true if the sender is known to not properly DKIM sign
 their email.
 :::
 
 :::{warning}
-Emails without proper authentication may have a spoofed
-message `From` domain, so take extra care to write YARA rules matching known
-safe content as detailed and narrow as possible.
+Emails without proper authentication may have a spoofed message `From`
+domain, so take extra care to write YARA rules matching known safe content as
+detailed and narrow as possible.
 :::
 
 ##### authentication_optional

--- a/test/trusted_domains_yara_safe_required.txt
+++ b/test/trusted_domains_yara_safe_required.txt
@@ -1,2 +1,0 @@
-myworkday.com
-email.sans.org

--- a/yaramail/__init__.py
+++ b/yaramail/__init__.py
@@ -488,11 +488,6 @@ class MailScanner(object):
         verdict = None
         multi_auth_headers = self.allow_multiple_authentication_results
         use_og_auth_results = self.use_authentication_results_original
-        yara_safe_optional_domain = from_trusted_domain(
-            parsed_email, self.yara_safe_optional_domains,
-            allow_multiple_authentication_results=multi_auth_headers,
-            use_authentication_results_original=use_og_auth_results,
-        )
         authenticated_domain = from_trusted_domain(
             parsed_email, [parsed_email["from"]["domain"]],
             allow_multiple_authentication_results=multi_auth_headers,

--- a/yaramail/__init__.py
+++ b/yaramail/__init__.py
@@ -520,17 +520,19 @@ class MailScanner(object):
         has_attachment = len(attachments) > 0
         for match in matches:
             auth_optional = False
+            if "authentication_optional" in match["meta"]:
+                auth_optional = match["meta"]["authentication_optional"]
             if "auth_optional" in match["meta"]:
                 auth_optional = match["meta"]["auth_optional"]
             passed_authentication = authenticated_domain or auth_optional
+            no_attachment = False
             if "no_attachments" in match["meta"]:
-                if match["meta"]["no_attachments"] and has_attachment:
-                    match["warnings"].append("unexpected-attachment")
-                    continue
+                no_attachment = match["meta"]["no_attachments"]
             if "no_attachment" in match["meta"]:
-                if match["meta"]["no_attachment"] and has_attachment:
-                    match["warnings"].append("unexpected-attachment")
-                    continue
+                no_attachment = match["meta"]["no_attachment"]
+            if no_attachment and has_attachment:
+                match["warnings"].append("unexpected-attachment")
+                continue
             rule_from_domains = None
             if "from_domains" in match["meta"]:
                 rule_from_domains = match["meta"]["from_domains"]

--- a/yaramail/__init__.py
+++ b/yaramail/__init__.py
@@ -516,8 +516,7 @@ class MailScanner(object):
                 if match["meta"]["category"] == "safe":
                     if "auth_optional" in match["meta"]:
                         auth_optional = match["meta"]["auth_optional"]
-                    authenticated = any([yara_safe_optional_domain,
-                                         auth_optional, authenticated_domain])
+                    authenticated = auth_optional or authenticated_domain
                     if not authenticated:
                         categories.append("yara_safe_auth_fail")
                         continue

--- a/yaramail/__init__.py
+++ b/yaramail/__init__.py
@@ -144,8 +144,8 @@ class MailScanner(object):
                  attachment_rules: Union[str, IOBase, yara.Rules] = None,
                  passwords: Union[List[str], IOBase, str] = None,
                  max_zip_depth: int = None,
-                 yara_safe_optional_domains: Union[List[str], IOBase,
-                                                   str] = None,
+                 implicit_safe_domains: Union[List[str], IOBase,
+                                              str] = None,
                  allow_multiple_authentication_results: bool = False,
                  use_authentication_results_original: bool = False):
         """
@@ -163,6 +163,8 @@ class MailScanner(object):
             passwords: A list of passwords to use when attempting to scan \
             password-protected files
             max_zip_depth: Number of times to recurse into nested ZIP files
+            implicit_safe_domains: Always add the ``safe`` category to \
+            emails from these domains
             allow_multiple_authentication_results: Allow multiple \
             ``Authentication-Results-Original`` headers when checking \
             authentication results
@@ -223,8 +225,8 @@ class MailScanner(object):
         self.passwords += ["malware", "infected"]
         self.passwords = _deduplicate_list(self.passwords)
         self.max_zip_depth = max_zip_depth
-        self.yara_safe_optional_domains = _input_to_str_list(
-            yara_safe_optional_domains)
+        self.implicit_safe_domains = _input_to_str_list(
+            implicit_safe_domains)
         allow_multi_auth = allow_multiple_authentication_results
         self.allow_multiple_authentication_results = allow_multi_auth
         use_og_auth = use_authentication_results_original
@@ -416,7 +418,7 @@ class MailScanner(object):
 
           - ``domain``  - The message From domain
           - ``domain_authenticated`` - bool: domain is authenticated
-          - ``yara_safe_optional`` - bool: YARA safe match is optional
+          - ``implicit_safe_domain`` - bool: YARA safe match is optional
             for the domain
 
         - ``has_attachment`` - bool: The email sample has an attachment
@@ -505,7 +507,7 @@ class MailScanner(object):
         multi_auth_headers = self.allow_multiple_authentication_results
         use_og_auth_results = self.use_authentication_results_original
         yara_safe_optional_domain = from_trusted_domain(
-            parsed_email, self.yara_safe_optional_domains,
+            parsed_email, self.implicit_safe_domains,
             allow_multiple_authentication_results=multi_auth_headers,
             use_authentication_results_original=use_og_auth_results,
         )
@@ -559,7 +561,7 @@ class MailScanner(object):
         msg_from_domain_results = dict(
             domain=msg_from_domain,
             authenticated=authenticated_domain,
-            yara_safe_optional=yara_safe_optional_domain)
+            implicit_safe_domain=yara_safe_optional_domain)
 
         return dict(matches=matches, categories=categories,
                     msg_from_domain=msg_from_domain_results,

--- a/yaramail/_cli.py
+++ b/yaramail/_cli.py
@@ -11,7 +11,7 @@ from mailsuite.utils import parse_email
 from yaramail import __version__, MailScanner
 
 formatter = logging.Formatter(
-    fmt='%(levelname)8s:%(message)s',
+    fmt='%(levelname)s:%(message)s',
     datefmt='%Y-%m-%d:%H:%M:%S')
 handler = logging.StreamHandler()
 handler.setFormatter(formatter)

--- a/yaramail/_cli.py
+++ b/yaramail/_cli.py
@@ -11,7 +11,7 @@ from mailsuite.utils import parse_email
 from yaramail import __version__, MailScanner
 
 formatter = logging.Formatter(
-    fmt='%(levelname)s:%(message)s',
+    fmt='%(levelname)s|%(message)s',
     datefmt='%Y-%m-%d:%H:%M:%S')
 handler = logging.StreamHandler()
 handler.setFormatter(formatter)

--- a/yaramail/_cli.py
+++ b/yaramail/_cli.py
@@ -74,12 +74,12 @@ arg_parser.add_argument("--passwords", type=str,
                              "password-protected files in addition to email "
                              "body content",
                         default="passwords.txt")
-arg_parser.add_argument("--yara-safe-optional-domains", type=str,
+arg_parser.add_argument("--implicit-safe-domains", type=str,
                         help="Filename of a list of message From domains that "
                              "return a safe verdict if the domain is "
                              "authenticated and no YARA categories match "
                              "other than safe",
-                        default="yara_safe_optional_domains.txt")
+                        default="implicit_safe_domains.txt")
 arg_parser.add_argument("--max-zip-depth", type=int,
                         help="The maximum number of times to recurse into "
                              "nested ZIP files")
@@ -119,24 +119,24 @@ def _main():
     if not os.path.exists(args.passwords):
         logger.warning(f"{args.passwords} does not exist.")
         args.passwords = None
-    args.yara_safe_optional_domains = os.path.join(
+    args.implicit_safe_domains = os.path.join(
         args.rules,
-        args.yara_safe_optional_domains)
-    if not os.path.exists(args.yara_safe_optional_domains):
-        logger.warning(f"{args.yara_safe_optional_domains} does not exist.")
-        args.yara_safe_optional_domains = None
+        args.implicit_safe_domains)
+    if not os.path.exists(args.implicit_safe_domains):
+        logger.warning(f"{args.implicit_safe_domains} does not exist.")
+        args.implicit_safe_domains = None
 
     yara_safe_optional_domains = []
-    if args.yara_safe_optional_domains is not None:
+    if args.implicit_safe_domains is not None:
         try:
-            with open(args.yara_safe_optional_domains) as yara_optional_file:
+            with open(args.implicit_safe_domains) as yara_optional_file:
                 yara_safe_optional_domains = yara_optional_file.read().strip()
                 yara_safe_optional_domains = yara_safe_optional_domains.split(
                     "\n"
                 )
         except Exception as e:
             logger.error(
-                f"Error reading {args.yara_safe_optional_domains}: {e}")
+                f"Error reading {args.implicit_safe_domains}: {e}")
 
     try:
         scanner = MailScanner(
@@ -144,7 +144,7 @@ def _main():
             body_rules=args.body_rules,
             header_body_rules=args.header_body_rules,
             attachment_rules=args.attachment_rules,
-            yara_safe_optional_domains=yara_safe_optional_domains,
+            implicit_safe_domains=yara_safe_optional_domains,
             passwords=args.passwords,
             allow_multiple_authentication_results=args.multi_auth,
             use_authentication_results_original=args.auth_original,

--- a/yaramail/_cli.py
+++ b/yaramail/_cli.py
@@ -71,7 +71,8 @@ arg_parser.add_argument("--attachment-rules", type=str,
                         default="attachment.yar")
 arg_parser.add_argument("--passwords", type=str,
                         help="Filename of a list of passwords to try against "
-                             "password-protected files",
+                             "password-protected files in addition to email "
+                             "body content",
                         default="passwords.txt")
 arg_parser.add_argument("--yara-safe-optional-domains", type=str,
                         help="Filename of a list of message From domains that "
@@ -183,13 +184,13 @@ def _main():
                             if verdict != category:
                                 results = simplejson.dumps(results)
                                 logger.error(
-                                    f"fail:path={msg_path}:verdict={verdict}:"
-                                    f"expected={category}:results={results}")
+                                    f"fail|path={msg_path}|verdict={verdict}|"
+                                    f"expected={category}|results={results}")
                                 test_failures += 1
                             elif verbose:
                                 logger.info(
-                                    f"pass:path={msg_path}:verdict={verdict}:"
-                                    f"expected={category}:results={results}")
+                                    f"pass|path={msg_path}|verdict={verdict}|"
+                                    f"expected={category}|results={results}")
                         except Exception as e_:
                             logger.warning(f"{msg_path}: {e_}")
                             test_failures += 1


### PR DESCRIPTION
*Warning*
This release is a major rewrite that includes changes breaking existing use

- Logic changes
  - Rules with a category of `safe` must have a `from_domain` `meta` value for the category to apply
    - This logic replaces `trusted_domains_yara_safe_required`
    -  `trusted_domain_yara_safe_required`, and `auth_optional` removed from results
  - The `auth_optional`rule `meta` key only applies to that rule 
  - Warnings are located inside a `warnings` list in each match, instead of as a `verdict`
    - A rule category does not apply if one or more warning is raised
      - Possible warnings include
        - `domain-authentication-failed` - Authentication of the message
            From domain failed
          - `from-domain-mismatch` - The message From domain did not exactly
            match the value of the `meta` key `from_domain`
          - `safe-rule-missing-from-domain` - The rule is missing a
            `from_domain` `meta` key that is required for rules with the
            `category` meta key set to `safe`
          - `unexpected-attachment` - An email win an attachment matched a
            rule with the `meta` key `no attachment` or `no_attachments`
            set to `true`
  - Trusted domains are now called implicit safe domains
- API changes
  - `trusted_domains` renamed to `implisit_safe_domains`
  - `trusted_domains_yara_safe_required` parameter removed
  - `include_sld_in_auth_check` parameter removed
  - Returned data structure changed (see docs for details)
- CLI changes
  - `--trusted-domains` renamed to `--implicit-safe-domains`
  - `--trusted-domains-yara` removed
  - `--sld` removed
  - Log output delimiter changed from `:` to `|` to avoid conflicting with JSON
