### PR TITLE
3.4.1: fix ZIP scanning bugs, drop dead --sld flag, bump mailsuite

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@
   (`attachment:archive.zip:attachment:archive.zip`).
 - A ZIP attachment with the ZIP magic bytes but a malformed body is now logged
   and skipped instead of raising `zipfile.BadZipFile`.
+- A malformed `.eml`/`.msg` attachment is now logged and skipped instead of
+  raising `ValueError`. The previous `except UserWarning` never matched the
+  exception `parse_email()` actually raises, so the error reached the caller.
 - `_scan_zip()` no longer reuses a previous member's contents when a later
   member cannot be decrypted, and it now continues scanning the remaining
   members instead of stopping at the first unreadable one.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,46 @@
 # Changelog
 
+## 3.4.1
+
+### Fixes
+
+- ZIP attachment scanning now reports the correct match `location`. The member
+  name was dropped before (`attachment:archive.zip:None`); it is now included
+  (`attachment:archive.zip:evil.js`), including for nested archives
+  (`attachment:first.zip:nested.zip:evil.js`).
+- `max_zip_depth` now limits nested-ZIP recursion as documented: `0` scans only
+  the top-level archive, `1` allows one nested level, and `None` is unlimited.
+  The comparison was inverted, so any positive value disabled recursion while
+  `0` recursed without limit.
+- ZIP attachment matches are no longer duplicated. A match was added once and
+  then re-added with a doubled location prefix
+  (`attachment:archive.zip:attachment:archive.zip`).
+- A ZIP attachment with the ZIP magic bytes but a malformed body is now logged
+  and skipped instead of raising `zipfile.BadZipFile`.
+- `_scan_zip()` no longer reuses a previous member's contents when a later
+  member cannot be decrypted, and it now continues scanning the remaining
+  members instead of stopping at the first unreadable one.
+- `_scan_zip()` no longer appends `infected` to the caller's password list.
+- `_carve_passwords()` no longer emits duplicate candidates (it modified the
+  list while iterating over it).
+- `use_raw_body=True` now scans both the plain-text and HTML parts when a
+  message has both, instead of dropping the plain-text part.
+- `_input_to_str_list()` drops every blank line, not just the first, and no
+  longer mutates a caller-supplied list.
+- Removed the `-s`/`--sld` CLI flag. It had no effect (the underlying
+  `include_sld_in_auth_check` option was removed in 3.0.0).
+- Fixed the `Changelog` project URL, which pointed at a `master` branch that
+  does not exist (the default branch is `main`).
+- Documentation typo, grammar, and stale-content fixes, including the CLI
+  reference, which still advertised the removed `-s`/`--sld` flag and
+  out-of-date `-v`/`--verbose` behavior.
+
+### Improvements
+
+- Minimum `mailsuite` version raised to `>=2.2.0` to pick up upstream fixes.
+- Narrowed broad `except Exception` handlers in the package to the specific
+  errors they recover from (`pdftotext.Error`, `zipfile.BadZipFile`).
+
 ## 3.4.0
 
 ### Fixes
@@ -100,7 +141,7 @@
 
 ## 3.1.2
 
-- Update minium `mailsuite` version to `>=1.9.12`
+- Update minimum `mailsuite` version to `>=1.9.12`
   - Fix parsing of `Authentication-Results` and `DKIM-Signature` headers when Windows line breaks (`\r\n`) are used
   - Strip leading and trailing spaces from `DKIM-Signature` header `h=` list item
 
@@ -110,7 +151,7 @@
 
 ## 3.1.0
 
-- Update minium `mailsuite` version to `>=1.9.9`
+- Update minimum `mailsuite` version to `>=1.9.9`
   - Fix header and body separation when Windows line breaks (`\r\n`) are used
 - CLI changes
   - Remove unused formats in verbose output
@@ -152,8 +193,8 @@ This release is a major rewrite that includes changes breaking existing use
           - `safe-rule-missing-from-domain` - The rule is missing a
             `from_domain` `meta` key that is required for rules with the
             `category` meta key set to `safe`
-          - `unexpected-attachment` - An email win an attachment matched a
-            rule with the `meta` key `no attachment` or `no_attachments`
+          - `unexpected-attachment` - An email with an attachment matched a
+            rule with the `meta` key `no_attachment` or `no_attachments`
             set to `true`
   - Trusted domains are now called implicit safe domains
 - API changes
@@ -193,7 +234,7 @@ This release is a major rewrite that includes changes breaking existing use
 
 ## 2.0.12
 
-- Output passing results along with failing results when `/t`/`--test` and `-v/--verbose` options are passed to the CLI
+- Output passing results along with failing results when `-t`/`--test` and `-v/--verbose` options are passed to the CLI
 
 ## 2.0.11
 
@@ -299,7 +340,7 @@ This release is a major rewrite that includes changes breaking existing use
 
 - Remove some documentation from `README.md`, so the PyPI listing won't have outdated info
 - Add `Issues` and `Changelog` URLs to the PyPI listing
-- Rename the `yaramail.cli` module to `yaramail.cli`
+- Rename the `yaramail.cli` module to `yaramail._cli`
 - Bump `mailsuite` dependency version to `>=1.9.2`
 
 ## 1.0.1

--- a/docs/source/cli.md
+++ b/docs/source/cli.md
@@ -1,7 +1,7 @@
 # CLI
 
 ```text
-usage: A YARA scanner for emails [-h] [-V] [-v] [-m] [-o] [-r] [-b] [-s] [-t]
+usage: A YARA scanner for emails [-h] [-V] [-v] [-m] [-o] [-r] [-b] [-t]
                                  [--output OUTPUT] [--rules RULES]
                                  [--header-rules HEADER_RULES]
                                  [--body-rules BODY_RULES]
@@ -21,9 +21,7 @@ positional arguments:
 options:
   -h, --help            show this help message and exit
   -V, --version         show program's version number and exit
-  -v, --verbose         Output the entire parsed email. When used with
-                        -t/--test, this option outputs passing results along
-                        with failing results. (default: False)
+  -v, --verbose         Output the entire parsed email. (default: False)
   -m, --multi-auth      Allow multiple Authentication-Results headers
                         (default: False)
   -o, --auth-original   Use Authentication-Results-Original instead of
@@ -32,9 +30,6 @@ options:
                         False)
   -b, --raw-body        Scan the raw email body instead of converting it to
                         Markdown first (default: False)
-  -s, --sld             Use From domain the Second-Level Domain (SLD) for
-                        authentication in addition to the Fully-Qualified
-                        Domain Name (FQDN) (default: False)
   -t, --test            Test rules based on verdicts matching the name of the
                         subdirectory a sample is in (default: False)
   --output OUTPUT       Redirect output to a file (default: None)

--- a/docs/source/collecting_samples.md
+++ b/docs/source/collecting_samples.md
@@ -1,12 +1,12 @@
 # Collecting email samples
 
 In order to be properly analyzed, email samples must be stored or sent with
-the full content intact, including any headers. The process of obtaining
-raw/original depends on the email service or client being used.
+the full content intact, including any headers. The process of obtaining the
+raw/original message depends on the email service or client being used.
 
 ## AOL webmail
 
-1. In the list of emails in your in inbox or folder, right-click on the message (not in the message itself)
+1. In the list of emails in your inbox or folder, right-click on the message (not in the message itself)
 2. Click View Message Source
 3. Select the entire raw message content, copy it, paste it into an empty text editor, and save the file with a `.eml` file extension
 
@@ -38,7 +38,7 @@ raw/original depends on the email service or client being used.
 3. From the Action Menu, select the “Forward As Attachment” Item
 4. Save the attachment(s) and/or send the email
 
-## Notes
+## HCL Notes (formerly Lotus Notes)
 
 1. Open the email
 2. Save it to a file by going to the File > Save As menu item
@@ -70,7 +70,7 @@ Attached emails can be saved to a file like any other attachment.
 
 ### Outlook Web Access (OWA)/Outlook.com
 
-1. Create a new email and leave it open a separate window.
+1. Create a new email and leave it open in a separate window.
 2. Drag the email from the inbox or other folder and drop it in the message of the draft.
 3. Download the attachment that was created in step 2
 

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -5,7 +5,7 @@
 [![PyPI - Downloads](https://img.shields.io/pypi/dm/yara-mail?color=blue)](https://pypistats.org/packages/yara-mail)
 
 yaramail is a Python package and command line utility for scanning emails with
-[YARA rules][yara]. It is Ideal for automated triage of phishing reports.
+[YARA rules][yara]. It is ideal for automated triage of phishing reports.
 
 <div style="text-align: center;">
   <iframe src="https://onedrive.live.com/embed?cid=5BEBF72EB17AB44F&amp;resid=5BEBF72EB17AB44F%2138962&amp;authkey=AGuJcdaXNmelzE0&amp;em=2&amp;wdAr=1.7777777777777777" width="476px" height="288px" frameborder="0">This is an embedded <a target="_blank" href="https://office.com">Microsoft Office</a> presentation, powered by <a target="_blank" href="https://office.com/webapps">Office</a>.</iframe>

--- a/docs/source/installation.md
+++ b/docs/source/installation.md
@@ -40,7 +40,7 @@ pip install yara-python
 3. Use Anaconda Navigator to create a new Anaconda Environment
 4. Click the play button for the Anaconda Environment
 5. Click Open Terminal
-6. Run `conda install -c conda-forge openssl poppler` and leave the terminal open:
+6. Run `conda install -c conda-forge openssl poppler` and leave the terminal open
 7. Configure your Python IDE/project to use the Anaconda Environment
 
 ## Install yaramail

--- a/docs/source/regex.md
+++ b/docs/source/regex.md
@@ -18,7 +18,7 @@
 | `\w`       | Any word character (letter, number, underscore)|
 | `\W`       | Any non-word character                         |
 | `\b`       | Any word boundary                              |
-| `(a\|b)`   |a or b                                          |
+| `(a\|b)`   | a or b                                         |
 | `a?`       | Zero or one of a                               |
 | `a*`       | Zero or more of a                              |
 | `a+`       | One or more of a                               |

--- a/docs/source/tutorial.md
+++ b/docs/source/tutorial.md
@@ -4,15 +4,15 @@
 
 ## Best practices
 
-it is **strongly recommended** to create a private Git repository as a place
-to develop, store, and maintain  YARA rules, trusted domain lists, and sample
+It is **strongly recommended** to create a private Git repository as a place
+to develop, store, and maintain YARA rules, trusted domain lists, and sample
 emails, for a number of reasons.
 
 - Version control tracks who made what change when, with easy rollback
 - Automation can (and should) pull a fresh copy of the repository
   before scanning
 - CI/CD workflows can [run tests](#testing-a-collection-of-samples)
-  against a collection of emails samples before allowing the rules into
+  against a collection of email samples before allowing the rules into
   production
 
 When automating phishing inbox triage, it is **vital** to continually [build
@@ -138,8 +138,8 @@ checking content against known malicious and trusted patterns.
 
 The purpose of `yaramail` is to identify known safe, known malicious, and
 likely junk email samples in phishing reporting inboxes. It will not catch
-everything. For proper automation, It is important to implement some form of
-deduplication for emails for reported emails that have been manually triaged.
+everything. For proper automation, it is important to implement some form of
+deduplication for reported emails that have been manually triaged.
 Consider using fuzzy matching approaches such as [ssdeep][ssdeep], or use
 machine learning capabilities included in many Security Orchestration Automation
 and Response (SOAR) platforms.
@@ -216,8 +216,8 @@ not contribute to the `verdict`.
 This key **must** be set for rules with a category of `safe`.
 :::
 
-If this key is set, the rule’s `category` only applies to emails when the
-message `From` domain that matches this value exactly. Multiple domains can be
+If this key is set, the rule’s `category` only applies to emails whose
+message `From` domain matches this value exactly. Multiple domains can be
 specified in this value by separating them with spaces.
 
 Domain authentication must pass, unless that rule has an `auth_optional` meta
@@ -263,7 +263,7 @@ Here are some simple examples.
 | `$magic`                            | The string assigned to the variable `$magic` must exist                                                                                                                                                  |
 | `$magic at 0`                       | The string assigned to the variable `$magic` must exist at offset `0`                                                                                                                                    |
 | `3 of ($foo_*)`                     | At least three instances of any string assigned to a variable starting with `$foo_` must exist                                                                                                           |
-| `(#foo_*) < 4`                      | The total number of instances of any string assigned to a variable starting with `$foo_`must be less than four                                                                                           |
+| `(#foo_*) < 4`                      | The total number of instances of any string assigned to a variable starting with `$foo_` must be less than four                                                                                          |
 | `$url and #url == (#trusted_url_*)` | At least one URL must exist **and** the number of instances of the string assigned to `$url` must equal the total number of instances of any string assigned to a variable starting with `$trusted_url_` |
 
 ## Practical YARA rule examples
@@ -508,7 +508,7 @@ Every Workday notification email
 
 - Has the message `From` domain `myworkday.com`
 - Is DKIM signed by a key at the domain `myworkday.com`
-- The organization's logo as a remote image
+- Includes the organization's logo as a remote image
 - Contains at least one link, and all link URLs start with
   `https://www.myworkday.com/` and the employer's name
 - Contains the string "Powered by Workday: A New Day, A Better Way."
@@ -578,10 +578,10 @@ Use a separate junk/marketing rule for each language spoken by your users.
 
 <script id="asciicast-529801" src="https://asciinema.org/a/529801.js" async></script>
 
-the [`yaramail` CLI](cli) has built-in support for scanning  individual
+The [`yaramail` CLI](cli) has built-in support for scanning individual
 samples, or an entire collection of samples.
 
-Use the `--rules`option to specify a path to a directory where the following
+Use the `--rules` option to specify a path to a directory where the following
 files can be found:
 
 - `header.yar` - Rules that apply to email header content
@@ -603,7 +603,7 @@ the scanner will still run using the data it does have.
 :::
 
 :::{note}
-Starting in version 1.2.0, the contents of the message body will always be
+Starting in version 2.1.0, the contents of the message body will always be
 tried as ZIP passwords, along with `infected` and `malware`.
 :::
 
@@ -699,13 +699,13 @@ for email in emails:
       attached_email = attachment
   if attached_email is None and report_email["valid_report"]:
     report_email["valid_report"] = False
-    # TODO: Tell use user how to properly send a sample as an attachment
+    # TODO: Tell the user how to properly send a sample as an attachment
     escalate_to_incident_response(report_email)
     # TODO: Move report email to the invalid folder or trash
     continue
   try:
     sample = scan_email(attached_email["payload"])
-    #TODO: Do something to deduplicate manually triaged emails
+    # TODO: Do something to deduplicate manually triaged emails
   except Exception as _e:
     logger.warning(f"Invalid email sample: {_e}")
     report_email["valid_report"] = False

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ classifiers = [
     "Topic :: Communications :: Email",
 ]
 dependencies = [
-    "mailsuite>=1.9.20",
+    "mailsuite>=2.2.0",
     "pdftotext==2.2.2",
     "simplejson>=3.17.6",
     "yara-python>=4.2.3",
@@ -58,7 +58,7 @@ yaramail = "yaramail._cli:_main"
 Homepage = "https://github.com/seanthegeek/yaramail"
 Documentation = "https://seanthegeek.github.io/yaramail/"
 Issues = "https://github.com/seanthegeek/yaramail/issues"
-Changelog = "https://github.com/seanthegeek/yaramail/blob/master/CHANGELOG.md"
+Changelog = "https://github.com/seanthegeek/yaramail/blob/main/CHANGELOG.md"
 
 [tool.hatch.version]
 path = "yaramail/__init__.py"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -296,6 +296,26 @@ def test_test_mode_reports_failures(
     assert code == 1
 
 
+def test_test_mode_aborts_on_unparseable_sample(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """In test mode, a sample that can't be parsed is logged and aborts with 1."""
+    corpus = tmp_path / "corpus"
+    category = corpus / "safe"
+    category.mkdir(parents=True)
+    (category / "broken.eml").write_text("\x00\x00 not a parseable email\x00")
+    code, _, err = _invoke(
+        "-t",
+        "-o",
+        str(corpus),
+        "--rules",
+        str(RULES_DIR),
+        capsys=capsys,
+    )
+    assert code == 1
+    assert "broken.eml" in err
+
+
 def test_unreadable_implicit_safe_domains_logs_error(
     tmp_path: Path, capsys: pytest.CaptureFixture[str]
 ) -> None:
@@ -319,6 +339,26 @@ def test_unreadable_implicit_safe_domains_logs_error(
     )
     assert code == 0
     assert "Error reading" in err
+
+
+def test_output_to_unwritable_path_logs_error(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """A --output path that can't be opened for writing is logged, not raised."""
+    sample = SAMPLES / "safe" / "workday.eml"
+    # A directory can't be opened with open(..., "w").
+    output_dir = tmp_path / "out-is-a-dir"
+    output_dir.mkdir()
+    code, _, err = _invoke(
+        str(sample),
+        "--rules",
+        str(RULES_DIR),
+        "--output",
+        str(output_dir),
+        "-o",
+        capsys=capsys,
+    )
+    assert "Error writing" in err
 
 
 def test_invalid_rules_exits_nonzero(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -58,8 +58,10 @@ def test_scan_single_file_emits_json(
     output = tmp_path / "result.json"
     code, _, _ = _invoke(
         str(sample),
-        "--rules", str(RULES_DIR),
-        "--output", str(output),
+        "--rules",
+        str(RULES_DIR),
+        "--output",
+        str(output),
         "-o",
         capsys=capsys,
     )
@@ -77,9 +79,11 @@ def test_scan_glob_with_no_matches_exits_nonzero(
 
 def test_test_mode_runs_all_samples(capsys: pytest.CaptureFixture[str]) -> None:
     code, out, _ = _invoke(
-        "-t", "-o",
+        "-t",
+        "-o",
         str(SAMPLES),
-        "--rules", str(RULES_DIR),
+        "--rules",
+        str(RULES_DIR),
         capsys=capsys,
     )
     data = json.loads(out)
@@ -89,20 +93,21 @@ def test_test_mode_runs_all_samples(capsys: pytest.CaptureFixture[str]) -> None:
 
 def test_test_mode_rejects_non_directory(capsys: pytest.CaptureFixture[str]) -> None:
     sample = SAMPLES / "safe" / "workday.eml"
-    code, _, _ = _invoke(
-        "-t", str(sample), "--rules", str(RULES_DIR), capsys=capsys
-    )
+    code, _, _ = _invoke("-t", str(sample), "--rules", str(RULES_DIR), capsys=capsys)
     assert code != 0
 
 
-@pytest.mark.parametrize("missing_arg", [
-    "--header-rules",
-    "--body-rules",
-    "--header-body-rules",
-    "--attachment-rules",
-    "--passwords",
-    "--implicit-safe-domains",
-])
+@pytest.mark.parametrize(
+    "missing_arg",
+    [
+        "--header-rules",
+        "--body-rules",
+        "--header-body-rules",
+        "--attachment-rules",
+        "--passwords",
+        "--implicit-safe-domains",
+    ],
+)
 def test_missing_rule_files_are_skipped_with_warning(
     missing_arg: str,
     tmp_path: Path,
@@ -112,9 +117,12 @@ def test_missing_rule_files_are_skipped_with_warning(
     output = tmp_path / "out.json"
     code, _, err = _invoke(
         str(sample),
-        "--rules", str(RULES_DIR),
-        missing_arg, "definitely-not-a-real-file.txt",
-        "--output", str(output),
+        "--rules",
+        str(RULES_DIR),
+        missing_arg,
+        "definitely-not-a-real-file.txt",
+        "--output",
+        str(output),
         "-o",
         capsys=capsys,
     )
@@ -150,9 +158,12 @@ def test_scan_verbose_with_single_file(
     sample = SAMPLES / "safe" / "workday.eml"
     output = tmp_path / "out.json"
     code, _, _ = _invoke(
-        str(sample), "-v",
-        "--rules", str(RULES_DIR),
-        "--output", str(output),
+        str(sample),
+        "-v",
+        "--rules",
+        str(RULES_DIR),
+        "--output",
+        str(output),
         "-o",
         capsys=capsys,
     )
@@ -164,9 +175,12 @@ def test_scan_verbose_with_single_file(
 
 def test_scan_test_mode_verbose(capsys: pytest.CaptureFixture[str]) -> None:
     code, out, _ = _invoke(
-        "-t", "-v", "-o",
+        "-t",
+        "-v",
+        "-o",
         str(SAMPLES),
-        "--rules", str(RULES_DIR),
+        "--rules",
+        str(RULES_DIR),
         capsys=capsys,
     )
     data = json.loads(out)
@@ -183,7 +197,8 @@ def test_scan_missing_file_logs_error(
     (tmp_path / "ghost.eml").write_text("garbage that is not parsable\n")
     code, _, err = _invoke(
         str(tmp_path / "ghost.eml"),
-        "--rules", str(RULES_DIR),
+        "--rules",
+        str(RULES_DIR),
         "-o",
         capsys=capsys,
     )
@@ -195,7 +210,10 @@ def test_scan_corrupt_stdin_logs_error(
     capsys: pytest.CaptureFixture[str],
 ) -> None:
     code, _, err = _invoke(
-        "-", "--rules", str(RULES_DIR), "-o",
+        "-",
+        "--rules",
+        str(RULES_DIR),
+        "-o",
         stdin="\x00\x00not an email\x00",
         capsys=capsys,
     )
@@ -209,9 +227,13 @@ def test_raw_headers_flag_strips_headers_string(
     sample = SAMPLES / "safe" / "workday.eml"
     output = tmp_path / "out.json"
     code, _, _ = _invoke(
-        str(sample), "-v", "-r",
-        "--rules", str(RULES_DIR),
-        "--output", str(output),
+        str(sample),
+        "-v",
+        "-r",
+        "--rules",
+        str(RULES_DIR),
+        "--output",
+        str(output),
         "-o",
         capsys=capsys,
     )
@@ -229,9 +251,13 @@ def test_raw_body_flag_strips_body_markdown(
     sample = SAMPLES / "safe" / "workday.eml"
     output = tmp_path / "out.json"
     code, _, _ = _invoke(
-        str(sample), "-v", "-b",
-        "--rules", str(RULES_DIR),
-        "--output", str(output),
+        str(sample),
+        "-v",
+        "-b",
+        "--rules",
+        str(RULES_DIR),
+        "--output",
+        str(output),
         "-o",
         capsys=capsys,
     )
@@ -256,9 +282,11 @@ def test_test_mode_reports_failures(
     # Non-.eml siblings should be skipped over.
     (misclassified / "README.txt").write_text("ignored")
     code, out, _ = _invoke(
-        "-t", "-o",
+        "-t",
+        "-o",
         str(corpus),
-        "--rules", str(RULES_DIR),
+        "--rules",
+        str(RULES_DIR),
         capsys=capsys,
     )
     data = json.loads(out)
@@ -283,8 +311,10 @@ def test_unreadable_implicit_safe_domains_logs_error(
     output = tmp_path / "out.json"
     code, _, err = _invoke(
         str(sample),
-        "--rules", str(rules),
-        "--output", str(output),
+        "--rules",
+        str(rules),
+        "--output",
+        str(output),
         capsys=capsys,
     )
     assert code == 0
@@ -298,8 +328,6 @@ def test_invalid_rules_exits_nonzero(
     bad_rules.mkdir()
     (bad_rules / "header.yar").write_text("this is not valid YARA")
     sample = SAMPLES / "safe" / "workday.eml"
-    code, _, err = _invoke(
-        str(sample), "--rules", str(bad_rules), capsys=capsys
-    )
+    code, _, err = _invoke(str(sample), "--rules", str(bad_rules), capsys=capsys)
     assert code != 0
     assert "Failed to parse YARA rules" in err

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -78,7 +78,7 @@ class TestInputToStrList:
 
 class TestCompileRules:
     def test_passes_through_compiled_rules(self) -> None:
-        compiled = yara.compile(source='rule r { condition: true }')
+        compiled = yara.compile(source="rule r { condition: true }")
         assert _compile_rules(compiled) is compiled
 
     def test_from_file_path(self) -> None:
@@ -94,11 +94,11 @@ class TestCompileRules:
         assert isinstance(rules, yara.Rules)
 
     def test_from_source_string(self) -> None:
-        rules = _compile_rules('rule r { condition: true }')
+        rules = _compile_rules("rule r { condition: true }")
         assert isinstance(rules, yara.Rules)
 
     def test_from_io_base(self) -> None:
-        rules = _compile_rules(StringIO('rule r { condition: true }'))
+        rules = _compile_rules(StringIO("rule r { condition: true }"))
         assert isinstance(rules, yara.Rules)
 
     def test_rejects_unsupported_type(self) -> None:
@@ -169,7 +169,7 @@ def test_scan_zip_with_in_memory_archive(tmp_path: Path) -> None:
 def test_scan_zip_rejects_non_zip() -> None:
     from yaramail import MailScanner
 
-    scanner = MailScanner(attachment_rules='rule r { condition: true }')
+    scanner = MailScanner(attachment_rules="rule r { condition: true }")
     with pytest.raises(ValueError, match="not a ZIP"):
         scanner._scan_zip(b"not a zip")
 
@@ -177,7 +177,7 @@ def test_scan_zip_rejects_non_zip() -> None:
 def test_scan_zip_missing_file(tmp_path: Path) -> None:
     from yaramail import MailScanner
 
-    scanner = MailScanner(attachment_rules='rule r { condition: true }')
+    scanner = MailScanner(attachment_rules="rule r { condition: true }")
     with pytest.raises(FileNotFoundError):
         scanner._scan_zip(str(tmp_path / "missing.zip"))
 
@@ -185,7 +185,7 @@ def test_scan_zip_missing_file(tmp_path: Path) -> None:
 def test_scan_pdf_text_rejects_non_pdf() -> None:
     from yaramail import MailScanner
 
-    scanner = MailScanner(attachment_rules='rule r { condition: true }')
+    scanner = MailScanner(attachment_rules="rule r { condition: true }")
     with pytest.raises(ValueError, match="not a PDF"):
         scanner._scan_pdf_text(b"not a pdf")
 

--- a/tests/test_scanner.py
+++ b/tests/test_scanner.py
@@ -22,8 +22,7 @@ PDF_MARKER_RULE = (
     'rule pdf_marker { strings: $a = "yaramail-pdf-marker" condition: $a }'
 )
 ENCRYPTED_ZIP_RULE = (
-    'rule zip_marker { strings: $a = "evil-marker inside encrypted zip" '
-    'condition: $a }'
+    'rule zip_marker { strings: $a = "evil-marker inside encrypted zip" condition: $a }'
 )
 
 
@@ -106,14 +105,13 @@ def test_scan_attachments_accepts_single_dict(tmp_path: Path) -> None:
 def test_safe_rule_without_from_domain_emits_warning() -> None:
     rule = (
         "rule loose_safe { "
-        "meta: category = \"safe\" "
+        'meta: category = "safe" '
         'strings: $a = "evil-marker" '
         "condition: $a }"
     )
     scanner = MailScanner(body_rules=rule)
     eml = (
-        "From: noone@example.com\r\nTo: a@b.c\r\n"
-        "Subject: x\r\n\r\nevil-marker here\r\n"
+        "From: noone@example.com\r\nTo: a@b.c\r\nSubject: x\r\n\r\nevil-marker here\r\n"
     )
     result = scanner.scan_email(eml)
     warnings = result["matches"][0]["warnings"]
@@ -123,7 +121,7 @@ def test_safe_rule_without_from_domain_emits_warning() -> None:
 def test_from_domain_mismatch_emits_warning() -> None:
     rule = (
         "rule scoped { "
-        "meta: category = \"phishing\" from_domain = \"trusted.example\" "
+        'meta: category = "phishing" from_domain = "trusted.example" '
         'strings: $a = "evil-marker" '
         "condition: $a }"
     )
@@ -164,10 +162,7 @@ def test_alt_meta_key_spellings_are_supported() -> None:
         'strings: $a = "marker" condition: $a }'
     )
     scanner = MailScanner(body_rules=rule)
-    eml = (
-        "From: x@b.example\r\nTo: y@z.example\r\n"
-        "Subject: x\r\n\r\nmarker here\r\n"
-    )
+    eml = "From: x@b.example\r\nTo: y@z.example\r\nSubject: x\r\n\r\nmarker here\r\n"
     result = scanner.scan_email(eml)
     # b.example is in the allowed list, so no from-domain-mismatch warning.
     warnings = result["matches"][0]["warnings"]
@@ -344,7 +339,7 @@ def test_scan_zip_does_not_mutate_passwords_argument() -> None:
     buf = BytesIO()
     with zipfile.ZipFile(buf, "w") as zf:
         zf.writestr("note.txt", "hello")
-    scanner = MailScanner(attachment_rules='rule r { condition: true }')
+    scanner = MailScanner(attachment_rules="rule r { condition: true }")
     passwords = ["hunter2"]
     scanner._scan_zip(buf.getvalue(), passwords=passwords)
     assert passwords == ["hunter2"]
@@ -373,7 +368,7 @@ def test_scan_zip_with_unreadable_entries_returns_empty(
     monkeypatch.setattr(zipfile.ZipFile, "open", always_fails)
     try:
         scanner = MailScanner(
-            attachment_rules='rule m { condition: true }',
+            attachment_rules="rule m { condition: true }",
         )
         assert scanner._scan_zip(archive.read_bytes()) == []
     finally:
@@ -568,7 +563,7 @@ def test_corrupt_zip_attachment_is_logged_not_raised(
 ) -> None:
     """A payload with the ZIP magic but a malformed body is logged, not raised."""
     bad = b"\x50\x4b\x03\x04" + b"garbage that is not a real zip"
-    scanner = MailScanner(attachment_rules='rule r { condition: true }')
+    scanner = MailScanner(attachment_rules="rule r { condition: true }")
     with caplog.at_level("WARNING", logger="yaramail"):
         result = scanner.scan_email(_zip_attachment_eml("bad.zip", bad))
     # The raw-archive scan still produced a match; the member scan was skipped.

--- a/tests/test_scanner.py
+++ b/tests/test_scanner.py
@@ -512,6 +512,44 @@ def test_scan_email_with_eml_attached_to_eml() -> None:
     assert any(match["rule"] == "m" for match in result["matches"])
 
 
+def test_malformed_eml_attachment_is_logged_not_raised(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A .eml attachment that isn't a parseable email is logged, not raised."""
+    garbage = base64.b64encode(b"\x00\x01 not an email").decode()
+    outer = (
+        "From: a@example.com\r\nTo: b@c.d\r\n"
+        'Content-Type: multipart/mixed; boundary="b1"\r\nSubject: x\r\n\r\n'
+        "--b1\r\nContent-Type: text/plain\r\n\r\nsee attachment\r\n--b1\r\n"
+        'Content-Type: application/octet-stream; name="nested.eml"\r\n'
+        "Content-Transfer-Encoding: base64\r\n"
+        'Content-Disposition: attachment; filename="nested.eml"\r\n\r\n'
+        f"{garbage}\r\n--b1--\r\n"
+    )
+    scanner = MailScanner(attachment_rules="rule r { condition: true }")
+    with caplog.at_level("WARNING", logger="yaramail"):
+        result = scanner.scan_email(outer)  # must not raise
+    assert "matches" in result
+    assert any("Unable to scan nested.eml" in rec.message for rec in caplog.records)
+
+
+def test_scan_zip_with_malformed_pdf_member_is_logged_not_raised(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A ZIP member with the PDF magic but a broken body is logged, not raised."""
+    buf = BytesIO()
+    with zipfile.ZipFile(buf, "w", zipfile.ZIP_DEFLATED) as zf:
+        zf.writestr("broken.pdf", b"%PDF-1.7\nnot really a pdf")
+    scanner = MailScanner(attachment_rules=PDF_MARKER_RULE)
+    with caplog.at_level("WARNING", logger="yaramail"):
+        matches = scanner._scan_zip(buf.getvalue())  # must not raise
+    assert matches == []
+    assert any(
+        "Unable to convert 'broken.pdf' to markdown" in rec.message
+        for rec in caplog.records
+    )
+
+
 def _zip_attachment_eml(filename: str, archive: bytes) -> str:
     zip_b64 = base64.b64encode(archive).decode()
     return (

--- a/tests/test_scanner.py
+++ b/tests/test_scanner.py
@@ -284,23 +284,70 @@ def test_scan_zip_accepts_bytesio(tmp_path: Path) -> None:
     assert any(m["rule"] == "m" for m in matches)
 
 
-def test_scan_zip_recurses_into_nested_archive_when_depth_exceeded(
-    tmp_path: Path,
-) -> None:
-    """With ``max_zip_depth=1``, the recursion guard allows one level deep."""
-    inner = tmp_path / "inner.zip"
-    with zipfile.ZipFile(inner, "w") as zf:
-        zf.writestr("deep.txt", "deep-marker")
-    outer = tmp_path / "outer.zip"
-    with zipfile.ZipFile(outer, "w") as zf:
-        zf.write(inner, arcname="inner.zip")
+def _nested_zip(levels: int, marker: bytes = b"deep-marker") -> bytes:
+    """Build ``levels`` of DEFLATE-compressed nested ZIPs around ``marker``.
 
+    Compression matters: with ZIP_STORED the marker would survive as plaintext
+    in every enclosing archive, so a scan would "find" it without recursing and
+    the depth guard would never actually be exercised.
+    """
+    buf = BytesIO()
+    with zipfile.ZipFile(buf, "w", zipfile.ZIP_DEFLATED) as zf:
+        zf.writestr("payload.txt", marker)
+    data = buf.getvalue()
+    for level in range(levels - 1):
+        buf = BytesIO()
+        with zipfile.ZipFile(buf, "w", zipfile.ZIP_DEFLATED) as zf:
+            zf.writestr(f"inner{level}.zip", data)
+        data = buf.getvalue()
+    return data
+
+
+def test_scan_zip_max_zip_depth_limits_recursion() -> None:
+    """``max_zip_depth`` is the number of times to recurse into nested ZIPs.
+
+    ``0`` scans only the top-level archive, ``1`` allows one nested level,
+    ``None`` is unlimited.
+    """
+    rule = 'rule m { strings: $a = "deep-marker" condition: $a }'
+    # outer.zip -> inner.zip -> payload.txt: one recursion is needed.
+    one_level = _nested_zip(2)
+
+    def found(depth: int | None, data: bytes) -> bool:
+        scanner = MailScanner(attachment_rules=rule, max_zip_depth=depth)
+        return any(m["rule"] == "m" for m in scanner._scan_zip(data))
+
+    assert found(None, one_level) is True
+    assert found(1, one_level) is True
+    assert found(0, one_level) is False  # no recursion at all
+
+    # Three levels deep needs two recursions.
+    two_levels = _nested_zip(3)
+    assert found(2, two_levels) is True
+    assert found(1, two_levels) is False
+
+
+def test_scan_zip_member_location_is_relative_to_archive() -> None:
+    """A ZIP-member match reports the member name, not ``None``."""
+    buf = BytesIO()
+    with zipfile.ZipFile(buf, "w", zipfile.ZIP_DEFLATED) as zf:
+        zf.writestr("evil.js", "evil-marker here")
     scanner = MailScanner(
-        attachment_rules='rule m { strings: $a = "deep-marker" condition: $a }',
-        max_zip_depth=1,
+        attachment_rules='rule m { strings: $a = "evil-marker" condition: $a }',
     )
-    matches = scanner._scan_zip(outer.read_bytes())
-    assert any(m["rule"] == "m" for m in matches)
+    matches = scanner._scan_zip(buf.getvalue())
+    assert [m["location"] for m in matches] == ["evil.js"]
+    assert "zip" in matches[0]["tags"]
+
+
+def test_scan_zip_does_not_mutate_passwords_argument() -> None:
+    buf = BytesIO()
+    with zipfile.ZipFile(buf, "w") as zf:
+        zf.writestr("note.txt", "hello")
+    scanner = MailScanner(attachment_rules='rule r { condition: true }')
+    passwords = ["hunter2"]
+    scanner._scan_zip(buf.getvalue(), passwords=passwords)
+    assert passwords == ["hunter2"]
 
 
 def test_scan_zip_with_unreadable_entries_returns_empty(
@@ -468,3 +515,78 @@ def test_scan_email_with_eml_attached_to_eml() -> None:
     )
     result = scanner.scan_email(outer)
     assert any(match["rule"] == "m" for match in result["matches"])
+
+
+def _zip_attachment_eml(filename: str, archive: bytes) -> str:
+    zip_b64 = base64.b64encode(archive).decode()
+    return (
+        "From: a@example.com\r\nTo: b@c.d\r\n"
+        'Content-Type: multipart/mixed; boundary="b1"\r\nSubject: x\r\n\r\n'
+        "--b1\r\nContent-Type: text/plain\r\n\r\nsee attachment\r\n--b1\r\n"
+        f'Content-Type: application/zip; name="{filename}"\r\n'
+        "Content-Transfer-Encoding: base64\r\n"
+        f'Content-Disposition: attachment; filename="{filename}"\r\n\r\n'
+        f"{zip_b64}\r\n--b1--\r\n"
+    )
+
+
+def test_zip_attachment_location_has_no_duplicates() -> None:
+    """A stored ZIP member matches both the raw archive scan and the member
+    scan, but each must appear once with a correct location."""
+    buf = BytesIO()
+    with zipfile.ZipFile(buf, "w", zipfile.ZIP_STORED) as zf:
+        zf.writestr("evil.js", "evil-marker here")
+    scanner = MailScanner(
+        attachment_rules='rule m { strings: $a = "evil-marker" condition: $a }',
+    )
+    result = scanner.scan_email(_zip_attachment_eml("archive.zip", buf.getvalue()))
+    locations = sorted(m["location"] for m in result["matches"])
+    # Exactly two distinct matches: the raw archive scan and the member scan.
+    assert locations == [
+        "attachment:archive.zip",
+        "attachment:archive.zip:evil.js",
+    ]
+
+
+def test_zip_attachment_nested_member_location_path() -> None:
+    inner = BytesIO()
+    with zipfile.ZipFile(inner, "w", zipfile.ZIP_DEFLATED) as zf:
+        zf.writestr("evil.js", "evil-marker here")
+    outer = BytesIO()
+    with zipfile.ZipFile(outer, "w", zipfile.ZIP_DEFLATED) as zf:
+        zf.writestr("nested.zip", inner.getvalue())
+    scanner = MailScanner(
+        attachment_rules='rule m { strings: $a = "evil-marker" condition: $a }',
+    )
+    result = scanner.scan_email(_zip_attachment_eml("first.zip", outer.getvalue()))
+    locations = {m["location"] for m in result["matches"]}
+    assert "attachment:first.zip:nested.zip:evil.js" in locations
+
+
+def test_corrupt_zip_attachment_is_logged_not_raised(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A payload with the ZIP magic but a malformed body is logged, not raised."""
+    bad = b"\x50\x4b\x03\x04" + b"garbage that is not a real zip"
+    scanner = MailScanner(attachment_rules='rule r { condition: true }')
+    with caplog.at_level("WARNING", logger="yaramail"):
+        result = scanner.scan_email(_zip_attachment_eml("bad.zip", bad))
+    # The raw-archive scan still produced a match; the member scan was skipped.
+    assert any(m["location"] == "attachment:bad.zip" for m in result["matches"])
+    assert any("Unable to scan bad.zip" in rec.message for rec in caplog.records)
+
+
+def test_use_raw_body_scans_both_plain_and_html() -> None:
+    rule = (
+        'rule both { strings: $a = "plain-token" $b = "html-token" '
+        "condition: all of them }"
+    )
+    scanner = MailScanner(body_rules=rule)
+    eml = (
+        "From: a@example.com\r\nTo: b@c.d\r\n"
+        'Content-Type: multipart/alternative; boundary="b1"\r\nSubject: x\r\n\r\n'
+        "--b1\r\nContent-Type: text/plain\r\n\r\nplain-token here\r\n--b1\r\n"
+        "--b1\r\nContent-Type: text/html\r\n\r\n<p>html-token</p>\r\n--b1--\r\n"
+    )
+    result = scanner.scan_email(eml, use_raw_body=True)
+    assert any(m["rule"] == "both" for m in result["matches"])

--- a/yaramail/__init__.py
+++ b/yaramail/__init__.py
@@ -449,7 +449,9 @@ class MailScanner(object):
                     nested = self.scan_email(parse_email(payload))
                     nested_matches = add_location(nested["matches"], filename)
                     combined_attachment_matches += nested_matches
-                except UserWarning as e:
+                except ValueError as e:
+                    # ``parse_email`` raises ValueError when the attachment is
+                    # not a parseable email.
                     logger.warning(f"Unable to scan {filename}. {e}.")
 
         return combined_attachment_matches

--- a/yaramail/__init__.py
+++ b/yaramail/__init__.py
@@ -14,7 +14,7 @@ from mailsuite.utils import parse_email, from_trusted_domain, decode_base64
 logger = logging.getLogger(__name__)
 logger.addHandler(logging.NullHandler())
 
-__version__ = "3.4.0"
+__version__ = "3.4.1"
 
 _T = TypeVar("_T")
 
@@ -71,20 +71,16 @@ for delimiter in delimiters:
 
 
 def _carve_passwords(content: str) -> list[str]:
-    passwords = []
+    passwords: list[str] = []
     for _regex in password_regex:
-        matches = _regex.findall(content)
-        passwords += matches
-    additional_passwords = []
-    for password in passwords:
-        # Make object type clear to IDEs
-        password = str(password)
-        # Account for any extra spaces added during markdown conversion
-        if " " in password:
-            additional_passwords.append(password.replace(" ", ""))
-            passwords += additional_passwords
-
-    return passwords
+        passwords += _regex.findall(content)
+    # Account for any extra spaces added during markdown conversion by also
+    # trying a space-stripped variant of every multi-word candidate.
+    additional_passwords = [
+        password.replace(" ", "") for password in passwords if " " in password
+    ]
+    passwords += additional_passwords
+    return _deduplicate_list(passwords)
 
 
 def _deduplicate_list(og_list: list[_T]) -> list[_T]:
@@ -141,7 +137,7 @@ def _is_pdf(file_bytes: bytes) -> bool:
 
 def _is_zip(file_bytes: bytes) -> bool:
     try:
-        return file_bytes.startswith(b"\x50\x4b\03\04")
+        return file_bytes.startswith(b"\x50\x4b\x03\x04")
     except TypeError:
         return False
 
@@ -165,11 +161,9 @@ def _input_to_str_list(_input: list[str] | str | IOBase | None) -> list[str]:
                 _list = f.read().split("\n")
     if isinstance(_input, StringIO):
         _list = _input.read().split("\n")
-    try:
-        _list.remove("")
-    except ValueError:
-        pass
-    return _list
+    # Drop every blank line (e.g. trailing newlines) without mutating a
+    # caller-supplied list in place.
+    return [item for item in _list if item != ""]
 
 
 def _compile_rules(rules: yara.Rules | IOBase | str) -> yara.Rules:
@@ -258,8 +252,8 @@ class MailScanner(object):
           solutions, such as Abnormal Security.
 
         .. note::
-          ``infected`, ``malware``, and the contents of the message body \
-            are always tried as passwords.
+          ``infected``, ``malware``, and the contents of the message body \
+          are always tried as passwords.
 
         .. note::
           Starting in version 2.1.0, the contents of the message body are \
@@ -326,64 +320,67 @@ class MailScanner(object):
             raise ValueError("Payload is not a ZIP file")
         payload = BytesIO(payload)
         _current_depth += 1
-        matches: list[dict[str, Any]] = []
-        tags: list[str] = []
         zip_matches: list[dict[str, Any]] = []
-        member_content: bytes | None = None
-        if passwords is None:
-            passwords = []
+        # Copy the password list so we never mutate the caller's argument.
+        passwords = list(passwords) if passwords else []
         if "infected" not in passwords:
             passwords.append("infected")
+        # ``None`` means "try without a password" and must be attempted first.
         pwd_candidates: list[bytes | None] = [None]
         pwd_candidates.extend(p.encode("utf-8") for p in passwords)
+
+        def tag_match(match: dict[str, Any], location: str) -> dict[str, Any]:
+            match["location"] = location
+            match["tags"] = _deduplicate_list(match["tags"] + ["zip"])
+            return match
+
         with zipfile.ZipFile(payload) as zip_file:
             for name in zip_file.namelist():
+                member_content: bytes | None = None
+                matches: list[dict[str, Any]] = []
                 for pwd in pwd_candidates:
-                    matches = []
                     try:
                         with zip_file.open(name, pwd=pwd) as member:
-                            tags = ["zip"]
-                            location = name
-                            if filename:
-                                location = "{}:{}".format(filename, name)
                             member_content = member.read()
                             matches = _match_to_dict(
                                 self._attachment_rules.match(data=member_content)
                             )
                             break
                     except RuntimeError:
+                        # Wrong password for this candidate; try the next one.
                         continue
 
                 if member_content is None:
-                    logger.warning("Unable to read the contents of the ZIP file")
-                    return zip_matches
+                    logger.warning(
+                        f"Unable to read {name!r} from the ZIP file "
+                        "(no working password found)"
+                    )
+                    continue
+
+                # The member's location is relative to this archive. When this
+                # archive is itself nested, ``filename`` carries the path to it
+                # so locations read e.g. ``nested.zip:evil.js``.
+                location = f"{filename}:{name}" if filename else name
                 for match in matches:
-                    location = None
-                    if "location" in match:
-                        existing_location = match["location"]
-                        location = f"{existing_location}:{location}"
-                    match["location"] = location
-                zip_matches += matches
+                    zip_matches.append(tag_match(match, location))
                 if _is_pdf(member_content):
                     try:
-                        zip_matches += self._scan_pdf_text(member_content)
-                    except Exception as e:
+                        for match in self._scan_pdf_text(member_content):
+                            zip_matches.append(tag_match(match, location))
+                    except pdftotext.Error as e:
                         logger.warning(
-                            "Unable to convert PDF to markdown. "
-                            f"{e} Scanning raw file content only"
-                            "."
+                            f"Unable to convert {name!r} to markdown. {e}. "
+                            "Scanning raw file content only."
                         )
                 elif _is_zip(member_content):
                     max_depth = self.max_zip_depth
-                    if max_depth is None or _current_depth > max_depth:
+                    if max_depth is None or _current_depth <= max_depth:
                         zip_matches += self._scan_zip(
                             member_content,
-                            filename=name,
+                            filename=location,
                             passwords=passwords,
                             _current_depth=_current_depth,
                         )
-                for match in zip_matches:
-                    match["tags"] = _deduplicate_list(match["tags"] + tags)
 
         return zip_matches
 
@@ -429,22 +426,23 @@ class MailScanner(object):
             combined_attachment_matches += attachment_matches
             if is_binary and _is_pdf(payload):
                 try:
-                    attachment_matches = self._scan_pdf_text(payload)
-                    attachment_matches = add_location(attachment_matches, filename)
-                    combined_attachment_matches += attachment_matches
-                except Exception as e:
+                    pdf_matches = self._scan_pdf_text(payload)
+                    pdf_matches = add_location(pdf_matches, filename)
+                    combined_attachment_matches += pdf_matches
+                except pdftotext.Error as e:
                     logger.warning(
                         f"Unable to convert {filename} to markdown. {e}. "
                         f"Scanning raw file content only."
                     )
             elif is_binary and _is_zip(payload):
                 try:
-                    attachment_matches += self._scan_zip(
-                        payload, passwords=passwords, filename=filename
-                    )
-                    attachment_matches = add_location(attachment_matches, filename)
-                    combined_attachment_matches += attachment_matches
-                except UserWarning as e:
+                    # ``_scan_zip`` returns locations relative to the archive
+                    # (e.g. ``evil.js``); ``add_location`` prepends the single
+                    # ``attachment:<filename>`` segment.
+                    zip_matches = self._scan_zip(payload, passwords=passwords)
+                    zip_matches = add_location(zip_matches, filename)
+                    combined_attachment_matches += zip_matches
+                except zipfile.BadZipFile as e:
                     logger.warning(f"Unable to scan {filename}. {e}.")
             elif file_extension in ["eml", "msg"]:
                 try:
@@ -508,8 +506,8 @@ class MailScanner(object):
           - ``safe-rule-missing-from-domain`` - The rule is missing a
             ``from_domain`` ``meta`` key that is required for rules with the
             ``category`` meta key set to ``safe``
-          - ``unexpected-attachment`` - An email win an attachment matched a
-            rule with the ``meta`` key ``no attachment`` or ``no_attachments``
+          - ``unexpected-attachment`` - An email with an attachment matched a
+            rule with the ``meta`` key ``no_attachment`` or ``no_attachments``
             set to ``true``
 
         - ``location`` - The part of the email where the match was
@@ -545,10 +543,14 @@ class MailScanner(object):
             headers = parsed_email["headers_string"]
         body = ""
         if use_raw_body:
+            # Scan both the plain-text and HTML parts so neither is dropped
+            # when a message provides both.
+            body_parts = []
             if len(parsed_email["text_plain"]) > 0:
-                body = "\n\n".join(parsed_email["text_plain"])
+                body_parts.append("\n\n".join(parsed_email["text_plain"]))
             if len(parsed_email["text_html"]) > 0:
-                body = "\n\n".join(parsed_email["text_html"])
+                body_parts.append("\n\n".join(parsed_email["text_html"]))
+            body = "\n\n".join(body_parts)
         else:
             body = parsed_email["body_markdown"]
         attachments = []

--- a/yaramail/_cli.py
+++ b/yaramail/_cli.py
@@ -63,14 +63,6 @@ arg_parser.add_argument(
     help="Scan the raw email body instead of converting it to Markdown first",
 )
 arg_parser.add_argument(
-    "-s",
-    "--sld",
-    action="store_true",
-    help="Use From domain the Second-Level Domain (SLD) "
-    "for authentication in addition to the "
-    "Fully-Qualified Domain Name (FQDN)",
-)
-arg_parser.add_argument(
     "-t",
     "--test",
     action="store_true",
@@ -193,7 +185,6 @@ def _main():
             max_zip_depth=args.max_zip_depth,
         )
     except Exception as e:
-        scanner = MailScanner()
         logger.error(f"Failed to parse YARA rules: {e}")
         exit(-1)
 


### PR DESCRIPTION
Patch release. Fixes a set of latent bugs surfaced in a code/docs review, plus documentation and tooling cleanup.

## Bug fixes

- **`max_zip_depth` recursion was inverted.** Any positive value disabled recursion entirely, while `0` recursed without limit. It now matches the docstring's "number of times to recurse": `0` = top-level archive only, `1` = one nested level, `None` = unlimited.
- **ZIP member `location` was always `None`.** The member name was computed and then discarded. Members now report their name, and nested archives resolve full paths. On the bundled `Invoice.eml` sample, the location went from `attachment:invoice.zip:None` → `attachment:invoice.zip:zapp-invoice.zip:zapp-invoice.pdf`.
- **ZIP attachment matches were duplicated and double-prefixed** (e.g. `attachment:a.zip:attachment:a.zip`). Each match now appears once with the correct location.
- **Corrupt-but-magic-valid ZIP attachments crashed.** A payload with the ZIP magic bytes but a malformed body raised `zipfile.BadZipFile` (the old `except UserWarning` never matched). It is now logged and skipped.
- **`_scan_zip` hardening:** no longer reuses a previous member's bytes when a later member can't be decrypted, continues past unreadable members instead of stopping at the first, and no longer mutates the caller's password list.
- **`_carve_passwords`** no longer emits duplicate candidates (it modified the list while iterating over it).
- **`use_raw_body=True`** now scans both the plain-text and HTML parts when a message has both, instead of dropping the plain-text part.
- **`_input_to_str_list`** drops every blank line, not just the first, without mutating a caller-supplied list.
- Removed the dead **`-s`/`--sld`** CLI flag (the underlying `include_sld_in_auth_check` option was removed in 3.0.0; the flag did nothing).
- Narrowed broad `except Exception` handlers in the package to `pdftotext.Error` / `zipfile.BadZipFile`.
- Fixed the `Changelog` project URL (`master` → `main`).

## Packaging

- Version bumped to **3.4.1**.
- Minimum **`mailsuite` raised to `>=2.2.0`** to pick up upstream fixes (verified compatible; full suite passes against 2.2.0).

## Docs & tests

- Documentation typo/grammar/stale-content fixes across `index`, `tutorial`, `collecting_samples`, `installation`, `regex`, the module docstring, and `CHANGELOG`; regenerated `cli.md` (drops `-s` and out-of-date `-v`/`--verbose` text).
- Tests expanded **93 → 99**, including a depth test that uses compression so the recursion guard is actually exercised, member/nested-location assertions, a no-duplicate assertion, a no-mutate-passwords test, a both-body-parts test, and a corrupt-ZIP regression test.
- `ruff format` applied to the test suite (separate commit).

## Verification

- `pytest`: 99 passed
- `ruff check yaramail tests` (the CI lint command): clean
- `ruff format --check`: clean
- `pyright` (strict): 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)