### PR TITLE
test: replace padding/weak assertions with behavioral ones

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -195,21 +195,20 @@ def test_scan_missing_file_logs_error(
     # the glob match, so we need a path that exists at glob time but fails to
     # open. Easier: create a directory matched by the glob.
     (tmp_path / "ghost.eml").write_text("garbage that is not parsable\n")
-    code, _, err = _invoke(
+    _, _, err = _invoke(
         str(tmp_path / "ghost.eml"),
         "--rules",
         str(RULES_DIR),
         "-o",
         capsys=capsys,
     )
-    # Output may be empty (exits -1) — we just want the error path exercised.
-    assert "Failed to" in err or code != 0
+    assert "Failed to parse email at" in err
 
 
 def test_scan_corrupt_stdin_logs_error(
     capsys: pytest.CaptureFixture[str],
 ) -> None:
-    code, _, err = _invoke(
+    _, _, err = _invoke(
         "-",
         "--rules",
         str(RULES_DIR),
@@ -217,8 +216,7 @@ def test_scan_corrupt_stdin_logs_error(
         stdin="\x00\x00not an email\x00",
         capsys=capsys,
     )
-    # The CLI logs and continues, returning -1 if no output was produced.
-    assert "Failed to" in err or code != 0
+    assert "Failed to scan email provided via stdin" in err
 
 
 def test_raw_headers_flag_strips_headers_string(

--- a/tests/test_scanner.py
+++ b/tests/test_scanner.py
@@ -15,7 +15,6 @@ from yaramail import MailScanner
 SAMPLES = Path(__file__).parent / "samples"
 FIXTURES = Path(__file__).parent / "fixtures"
 SANS = (SAMPLES / "safe" / "sans.eml").read_text()
-WORKDAY = (SAMPLES / "safe" / "workday.eml").read_text()
 INVOICE = (SAMPLES / "credential-harvesting" / "Invoice.eml").read_text()
 
 PDF_MARKER_RULE = (
@@ -45,11 +44,24 @@ def test_scan_email_accepts_bytes_input() -> None:
     assert result["msg_from_domain"]["domain"] == "email.sans.org"
 
 
-def test_scan_email_use_raw_headers_and_body() -> None:
-    scanner = MailScanner(use_authentication_results_original=True)
-    parsed = parse_email(WORKDAY)
-    result = scanner.scan_email(parsed, use_raw_headers=True, use_raw_body=True)
-    assert "matches" in result
+def test_use_raw_headers_scans_folded_headers_verbatim() -> None:
+    """``use_raw_headers`` keeps header folding; the default unfolds it.
+
+    mailsuite unfolds continuation lines in ``headers_string`` (the default
+    scan target) but leaves ``raw_headers`` intact, so a rule matching the
+    indented continuation only fires when ``use_raw_headers=True``.
+    """
+    rule = 'rule folded { strings: $a = "first\\r\\n\\tsecond" condition: $a }'
+    eml = (
+        "From: a@example.com\r\nTo: b@c.d\r\n"
+        "X-Folded: first\r\n\tsecond\r\nSubject: x\r\n\r\nbody\r\n"
+    )
+    scanner = MailScanner(header_rules=rule)
+    # Default unfolds the header ("first second"), so the rule does not match.
+    assert scanner.scan_email(eml)["matches"] == []
+    raw = scanner.scan_email(eml, use_raw_headers=True)
+    assert [m["rule"] for m in raw["matches"]] == ["folded"]
+    assert raw["matches"][0]["location"] == "header"
 
 
 def test_credential_harvesting_zip_attachment_classification() -> None:


### PR DESCRIPTION
Test-suite quality cleanup, independent of the 3.4.1 release PR (#11). No production code changes.

## What and why

- **`test_scan_email_use_raw_headers_and_body`** asserted only `"matches" in result`, which is **tautological** — `scan_email` always returns a dict with a `matches` key, so the test could only fail by crashing. And `use_raw_headers`'s actual effect was untested anywhere. Replaced it with a behavioral test: a rule matching a folded header's indented continuation matches **only** when `use_raw_headers=True`, because the default `headers_string` unfolds continuation lines while `raw_headers` keeps them. (Also drops the now-unused `WORKDAY` constant.)
- **`test_scan_missing_file_logs_error`** and **`test_scan_corrupt_stdin_logs_error`** asserted `"Failed to" in err or code != 0`. The `or` meant either condition passing satisfied the test, so it didn't actually pin the behavior. Both now assert the specific log message, and the unused `code` is dropped.

## Verification

- `pytest`: 93 passed
- `ruff check yaramail tests` (CI lint command): clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)