### PR TITLE
ci: update GitHub Actions to their latest major versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,10 +21,10 @@ jobs:
     name: Lint and type-check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v7
         with:
           python-version: "3.12"
           cache: pip
@@ -69,10 +69,10 @@ jobs:
       matrix:
         python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v7
         with:
           python-version: ${{ matrix.python-version }}
           cache: pip
@@ -90,7 +90,7 @@ jobs:
         run: pytest --cov=yaramail --cov-report=xml --cov-report=term --junitxml=junit.xml -o junit_family=legacy
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v7
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: false

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -24,10 +24,10 @@ jobs:
       pages: write
       id-token: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v7
         with:
           python-version: "3.12"
           cache: pip
@@ -49,13 +49,13 @@ jobs:
           make html
 
       - name: Configure Pages
-        uses: actions/configure-pages@v5
+        uses: actions/configure-pages@v6
 
       - name: Upload Pages artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
         with:
           path: docs/build/html
 
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,10 +26,10 @@ jobs:
     needs: ci
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v7
         with:
           python-version: "3.12"
 
@@ -49,7 +49,7 @@ jobs:
         run: hatch build
 
       - name: Upload distributions
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: dist
           path: dist/
@@ -65,7 +65,7 @@ jobs:
       id-token: write
     steps:
       - name: Download distributions
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: dist
           path: dist/
@@ -80,10 +80,10 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Download distributions
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: dist
           path: dist/


### PR DESCRIPTION
Updates every third-party action in the workflows to its newest major version:

| Action | From | To |
|---|---|---|
| actions/checkout | v4 | v7 |
| actions/setup-python | v5 | v7 |
| actions/upload-artifact | v4 | v7 |
| actions/download-artifact | v4 | v8 |
| actions/configure-pages | v5 | v6 |
| actions/upload-pages-artifact | v3 | v5 |
| actions/deploy-pages | v4 | v5 |
| codecov/codecov-action | v5 | v7 |

Unchanged on purpose: codecov/test-results-action@v1 is still the latest major, and pypa/gh-action-pypi-publish@release/v1 tracks the newest v1 release by design.

## Compatibility notes

I read the release notes for every major version being crossed. They are almost all Node 24 runtime upgrades and ESM migrations, which need no workflow changes on GitHub-hosted runners. The behavioral changes that do exist don't affect this repo:

- **download-artifact v5** changed the extraction path only for downloads by artifact **ID**; release.yml downloads by name (`name: dist`), which is unchanged. v8 also makes digest mismatches fail the run by default, a safety improvement.
- **upload-pages-artifact v4** stopped including hidden files by default. The Sphinx HTML output needs no hidden files to serve (Pages deployments through deploy-pages don't run Jekyll, so `.nojekyll` is irrelevant).
- **setup-python v7** removed the `pip-install` input, which these workflows don't use.
- **checkout v7** blocks checking out fork PRs on `pull_request_target`/`workflow_run` triggers, which these workflows don't use.

🤖 Generated with [Claude Code](https://claude.com/claude-code)